### PR TITLE
Upgrade target and compileSdkVersion of android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 34
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
This is needed for android build release. it required the target and compileSdkVersion to 31 to build success.